### PR TITLE
#28761 - Added tags to customer list filter

### DIFF
--- a/Resources/services/subscriber.xml
+++ b/Resources/services/subscriber.xml
@@ -14,5 +14,9 @@
             <argument>%neti_tags.plugin_dir%</argument>
             <tag name="shopware.event_subscriber"/>
         </service>
+        <service class="NetiTags\Subscriber\CustomerSubscriber" id="neti_tags.subscriber.customer_subscriber">
+            <argument type="service" id="neti_tags.service.table_registry" />
+            <tag name="shopware.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/Resources/snippets/plugins/neti_tags/backend/detail/relations/customer.ini
+++ b/Resources/snippets/plugins/neti_tags/backend/detail/relations/customer.ini
@@ -1,10 +1,13 @@
 [de_DE]
-name               = 'Kunde'
-grid_column_email  = 'E-Mail'
-grid_column_number = 'Kundennummer'
-grid_column_name   = 'Name'
+customer_list_filter_field_label = 'Tags'
+grid_column_email                = 'E-Mail'
+grid_column_name                 = 'Name'
+grid_column_number               = 'Kundennummer'
+name                             = 'Kunde'
+
 [en_GB]
-name               = 'Customer'
-grid_column_email  = 'Email'
-grid_column_number = 'Number'
-grid_column_name   = 'Name'
+customer_list_filter_field_label = 'Tags'
+grid_column_email                = 'Email'
+grid_column_name                 = 'Name'
+grid_column_number               = 'Number'
+name                             = 'Customer'

--- a/Resources/views/backend/neti_tags/extensions/view/main/customer_list_filter.js
+++ b/Resources/views/backend/neti_tags/extensions/view/main/customer_list_filter.js
@@ -1,0 +1,22 @@
+//{namespace name="plugins/neti_tags/backend/detail/relations/customer"}
+// {block name="backend/customer/view/main/customer_list_filter"}
+//{$smarty.block.parent}
+Ext.override(Shopware.apps.Customer.view.main.CustomerListFilter, {
+    'configure': function() {
+        var me = this,
+            configuration = me.callParent(arguments),
+            factory = Ext.create('Shopware.attribute.SelectionFactory'),
+            tagsStore = factory.createEntitySearchStore("NetiTags\\Models\\Tag");
+
+        configuration.fields.tags = {
+            'fieldLabel': '{s name="customer_list_filter_field_label"}Tags{/s}',
+            'xtype': 'combobox',
+            'displayField': 'title',
+            'valueField': 'id',
+            'store': tagsStore
+        };
+
+        return configuration;
+    }
+});
+//{/block}

--- a/Resources/views/backend/neti_tags/extensions/view/main/customer_list_filter.js
+++ b/Resources/views/backend/neti_tags/extensions/view/main/customer_list_filter.js
@@ -10,7 +10,7 @@ Ext.override(Shopware.apps.Customer.view.main.CustomerListFilter, {
 
         configuration.fields.tags = {
             'fieldLabel': '{s name="customer_list_filter_field_label"}Tags{/s}',
-            'xtype': 'combobox',
+            'xtype': 'netipagingcombobox',
             'displayField': 'title',
             'valueField': 'id',
             'store': tagsStore

--- a/Resources/views/backend/neti_tags/extensions/view/model/customer/quick_view.js
+++ b/Resources/views/backend/neti_tags/extensions/view/model/customer/quick_view.js
@@ -1,0 +1,4 @@
+// {block name="backend/customer/model/quick_view/fields"}
+//{$smarty.block.parent}
+{ name: 'tags', type: 'string' },
+//{/block}

--- a/Subscriber/Backend.php
+++ b/Subscriber/Backend.php
@@ -81,6 +81,8 @@ class Backend implements SubscriberInterface
         );
 
         $view->extendsTemplate('backend/neti_tags/extensions/view/customer/customer_stream/listing.js');
+        $view->extendsTemplate('backend/neti_tags/extensions/view/model/customer/quick_view.js');
+        $view->extendsTemplate('backend/neti_tags/extensions/view/main/customer_list_filter.js');
     }
 
     /**

--- a/Subscriber/CustomerSubscriber.php
+++ b/Subscriber/CustomerSubscriber.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @copyright  Copyright (c) 2018, Net Inventors GmbH
+ * @category   NetiTags
+ * @author     bmueller
+ */
+
+namespace NetiTags\Subscriber;
+
+use Doctrine\ORM\Query;
+use Enlight\Event\SubscriberInterface;
+use NetiTags\Models\Relation as TagRelationModel;
+use NetiTags\Service\TableRegistryInterface;
+use Shopware\Components\Model\QueryBuilder;
+
+/**
+ * Class CustomerSubscriber
+ *
+ * @package NetiTags\Subscriber
+ */
+class CustomerSubscriber implements SubscriberInterface
+{
+    /**
+     * @var TableRegistryInterface
+     */
+    protected $tableRegistry;
+
+    /**
+     * CustomerSubscriber constructor.
+     *
+     * @param TableRegistryInterface $tableRegistry
+     */
+    public function __construct(
+        TableRegistryInterface $tableRegistry
+    ) {
+        $this->tableRegistry = $tableRegistry;
+    }
+
+    /**
+     * Returns an array of event names this subscriber wants to listen to.
+     *
+     * The array keys are event names and the value can be:
+     *
+     *  * The method name to call (position defaults to 0)
+     *  * An array composed of the method name to call and the priority
+     *  * An array of arrays composed of the method names to call and respective
+     *    priorities, or 0 if unset
+     *
+     * For instance:
+     *
+     * <code>
+     * return array(
+     *     'eventName0' => 'callback0',
+     *     'eventName1' => array('callback1'),
+     *     'eventName2' => array('callback2', 10),
+     *     'eventName3' => array(
+     *         array('callback3_0', 5),
+     *         array('callback3_1'),
+     *         array('callback3_2')
+     *     )
+     * );
+     *
+     * </code>
+     *
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'Shopware_Controllers_Backend_CustomerQuickView::getListQuery::after'        => 'afterGetListQuery',
+            'Shopware_Controllers_Backend_CustomerQuickView::getFilterConditions::after' => 'afterGetFilterConditions',
+        );
+    }
+
+    /**
+     * @param \Enlight_Hook_HookArgs $args
+     */
+    public function afterGetListQuery(\Enlight_Hook_HookArgs $args)
+    {
+        $registeredTable = $this->tableRegistry->getByTableName('s_user');
+        if (null === $registeredTable) {
+            return;
+        }
+
+        /**
+         * @var QueryBuilder $query
+         */
+        $query = $args->getReturn();
+        $query->leftJoin(
+            TagRelationModel::class,
+            'tagRelations',
+            Query\Expr\Join::WITH,
+            'tagRelations.relationId = customer.id 
+                AND tagRelations.tableRegistryId = :tableRegistryId'
+        );
+        $query->setParameter(':tableRegistryId', $registeredTable->getId());
+
+        $args->setReturn($query);
+    }
+
+    /**
+     * @param \Enlight_Hook_HookArgs $args
+     */
+    public function afterGetFilterConditions(\Enlight_Hook_HookArgs $args)
+    {
+        $conditions = $args->getReturn();
+        $filters    = $args->get('filters');
+
+        foreach ($filters as $filter) {
+            if ('tags' !== $filter['property']) {
+                continue;
+            }
+
+            $filter['property'] = 'tagRelations.tagId';
+            $conditions[]       = $filter;
+        }
+
+        $args->setReturn($conditions);
+    }
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,11 +5,19 @@
     <label lang="de">Tags</label>
     <label lang="en">Tags</label>
 
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <link>http://www.netinventors.de</link>
     <author>Net Inventors GmbH</author>
     <compatibility minVersion="5.2.6"/>
 
+    <changelog version="1.2.0">
+        <changes lang="de"><![CDATA[
+[#2876] Tags zum Kundenlistenfilter hinzugefügt
+]]></changes>
+        <changes lang="en"><![CDATA[
+[#2876] Added tags to customer list filter
+]]></changes>
+    </changelog>
     <changelog version="1.1.0">
         <changes lang="de"><![CDATA[
 [#28251] Tags zu Product und Customer Streams hinzugefügt

--- a/plugin.xml
+++ b/plugin.xml
@@ -12,10 +12,10 @@
 
     <changelog version="1.2.0">
         <changes lang="de"><![CDATA[
-[#2876] Tags zum Kundenlistenfilter hinzugefügt
+[#28761] Tags zum Kundenlistenfilter hinzugefügt
 ]]></changes>
         <changes lang="en"><![CDATA[
-[#2876] Added tags to customer list filter
+[#28761] Added tags to customer list filter
 ]]></changes>
     </changelog>
     <changelog version="1.1.0">


### PR DESCRIPTION
Testing:

1. Go to the customer view over the mainline menu "Kunden => Kunden"
2. Expand the filter on the left side
3. Scroll down at the filter view to the tags
4. Select a tag, that related with an customer
5. Now only you see the customers with this tag